### PR TITLE
fix: refer token as a property of AccessToken

### DIFF
--- a/routes/frontend.js
+++ b/routes/frontend.js
@@ -72,7 +72,7 @@ export default async function frontend (fastify, opts) {
   async function onLoginCallback (req, reply) {
     // In every route and hook, the `this` is the
     // current Fastify instance!
-    const token = await this.github.getAccessTokenFromAuthorizationCodeFlow(req)
+    const { token } = await this.github.getAccessTokenFromAuthorizationCodeFlow(req)
     await this.isUserAllowed(token.access_token)
 
     // Keep always security in mind!


### PR DESCRIPTION
Thank you for this project. It is very helpful with fastify exploration. 

I found a little thing which needs to to fixed. The method `getAccessTokenFromAuthorizationCodeFlow(...)` now returns [AccessToken](https://github.com/lelylan/simple-oauth2/blob/master/API.md#accesstoken) which in turn has property token (instead token object directly)